### PR TITLE
remove relative path to directory "tests"

### DIFF
--- a/loop.sh
+++ b/loop.sh
@@ -39,8 +39,8 @@ function control() {
 }
 
 # Verify that folder exist
-if [ ! -d "tests/$SERVER" ]; then
-  echo "The directory tests/$SERVER was not found, you need to check your start parameter"
+if [ ! -d "$SERVER" ]; then
+  echo "The directory $SERVER was not found, you need to check your start parameter"
   rm $CONTROL_FILE
   exit 1
 fi


### PR DESCRIPTION
The subdirectory "tests" does not currently exist in the directory structure and there is also no need for it.
For people just cloning the template project this reference should be removed otherwise the example run command mentioned in README.md will not work out-of-the-box.